### PR TITLE
Add various fluid blocks to `minecraft:replaceable`

### DIFF
--- a/src/generated/resources/data/minecraft/tags/blocks/replaceable.json
+++ b/src/generated/resources/data/minecraft/tags/blocks/replaceable.json
@@ -1,0 +1,24 @@
+{
+  "values": [
+    {
+      "id": "gtceu:oil",
+      "required": false
+    },
+    {
+      "id": "gtceu:oil_light",
+      "required": false
+    },
+    {
+      "id": "gtceu:oil_heavy",
+      "required": false
+    },
+    {
+      "id": "gtceu:oil_medium",
+      "required": false
+    },
+    {
+      "id": "gtceu:natural_gas",
+      "required": false
+    }
+  ]
+}

--- a/src/main/java/com/gregtechceu/gtceu/data/tags/BlockTagLoader.java
+++ b/src/main/java/com/gregtechceu/gtceu/data/tags/BlockTagLoader.java
@@ -4,10 +4,12 @@ import com.gregtechceu.gtceu.api.data.chemical.ChemicalHelper;
 import com.gregtechceu.gtceu.api.data.chemical.material.Material;
 import com.gregtechceu.gtceu.api.data.tag.TagPrefix;
 import com.gregtechceu.gtceu.api.data.tag.TagUtil;
+import com.gregtechceu.gtceu.common.data.GTMaterials;
 import com.gregtechceu.gtceu.data.recipe.CustomTags;
 import com.tterrag.registrate.providers.RegistrateTagsProvider;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.BlockTags;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
@@ -18,6 +20,13 @@ public class BlockTagLoader {
         create(provider, CustomTags.CONCRETE_BLOCK, Blocks.WHITE_CONCRETE, Blocks.ORANGE_CONCRETE, Blocks.MAGENTA_CONCRETE, Blocks.LIGHT_BLUE_CONCRETE, Blocks.YELLOW_CONCRETE, Blocks.LIME_CONCRETE, Blocks.PINK_CONCRETE, Blocks.GRAY_CONCRETE, Blocks.LIGHT_GRAY_CONCRETE, Blocks.CYAN_CONCRETE, Blocks.PURPLE_CONCRETE, Blocks.BLUE_CONCRETE, Blocks.BROWN_CONCRETE, Blocks.GREEN_CONCRETE, Blocks.RED_CONCRETE, Blocks.BLACK_CONCRETE);
         create(provider, CustomTags.CONCRETE_POWDER_BLOCK, Blocks.WHITE_CONCRETE_POWDER, Blocks.ORANGE_CONCRETE_POWDER, Blocks.MAGENTA_CONCRETE_POWDER, Blocks.LIGHT_BLUE_CONCRETE_POWDER, Blocks.YELLOW_CONCRETE_POWDER, Blocks.LIME_CONCRETE_POWDER, Blocks.PINK_CONCRETE_POWDER, Blocks.GRAY_CONCRETE_POWDER, Blocks.LIGHT_GRAY_CONCRETE_POWDER, Blocks.CYAN_CONCRETE_POWDER, Blocks.PURPLE_CONCRETE_POWDER, Blocks.BLUE_CONCRETE_POWDER, Blocks.BROWN_CONCRETE_POWDER, Blocks.GREEN_CONCRETE_POWDER, Blocks.RED_CONCRETE_POWDER, Blocks.BLACK_CONCRETE_POWDER);
         create(provider, CustomTags.ENDSTONE_ORE_REPLACEABLES, Blocks.END_STONE);
+
+        create(provider, BlockTags.REPLACEABLE,
+            GTMaterials.Oil.getFluid().defaultFluidState().createLegacyBlock().getBlock(),
+            GTMaterials.OilLight.getFluid().defaultFluidState().createLegacyBlock().getBlock(),
+            GTMaterials.OilHeavy.getFluid().defaultFluidState().createLegacyBlock().getBlock(),
+            GTMaterials.RawOil.getFluid().defaultFluidState().createLegacyBlock().getBlock(),
+            GTMaterials.NaturalGas.getFluid().defaultFluidState().createLegacyBlock().getBlock());
     }
 
     private static void create(RegistrateTagsProvider<Block> provider, String tagName, ResourceLocation... rls) {


### PR DESCRIPTION
## What
Adds some replaceable fluid blocks to the `minecraft:replaceable` block tag, since one mod in particular *cough* TFC *cough* likes to complain if they aren't included in the tag.